### PR TITLE
Set A Far Future Cache Expiration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
   TargetRubyVersion: 2.3
 Documentation:
   Enabled: false
+# Slightly longer classes
+Metrics/ClassLength:
+  Max: 125
 # RSpec uses long blocks (i.e. describe, it, etc.)
 Metrics/BlockLength:
   Exclude:

--- a/lib/ama/styles/globals.rb
+++ b/lib/ama/styles/globals.rb
@@ -13,6 +13,7 @@ module AMA
       FALLBACK_STYLESHEET_NAME = 'fallback'
       FALLBACK_STYLESHEET_FILE = "#{FALLBACK_STYLESHEET_NAME}.css"
       ASSET_PREFIX = 'assets/'
+      FAR_FUTURE_CACHE_EXPIRATION = 30.years.freeze
 
       def root_path
         Rails.root

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end


### PR DESCRIPTION
:elephant:
* For performance, tell S3 to set a far-future cache expiration of
  30 years in the future. This helps optimize delivery by letting
  clients cache the content (almost) indefinitely. If any file
  changes, the sprockets digest of the file will change - effectively
  breaking the cache.
* Slightly bump allowed class length in rubocop.