### PR TITLE
Specifying quote callout width

### DIFF
--- a/app/assets/stylesheets/layout_components/callouts/quote-callout.scss
+++ b/app/assets/stylesheets/layout_components/callouts/quote-callout.scss
@@ -2,5 +2,6 @@
   &__content{
     @include absolute-center;
     text-align: center;
+    width: 90%;
   }
 }

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
   end
 end


### PR DESCRIPTION
So it doesn't squish in forcing text to wrap in ugly ways.

Before: 
![image](https://cloud.githubusercontent.com/assets/473578/23681451/3b5dadf4-034c-11e7-82b2-21d7dde99c7d.png)

After:
![image](https://cloud.githubusercontent.com/assets/473578/23681571/b0cf1c26-034c-11e7-8caf-10b368dbcdfe.png)

🎨 

https://ama-digital.myjetbrains.com/youtrack/issue/INSAQ-1027