### PR TITLE
Adding mobile overrides for mb0 and pb0 classes

### DIFF
--- a/app/assets/stylesheets/layout/helper-classes.scss
+++ b/app/assets/stylesheets/layout/helper-classes.scss
@@ -112,6 +112,12 @@
 
 .mb0{
   margin-bottom: 0 !important;
+
+  &--mobile-mb1{
+    @include breakpoint(small only){
+      margin-bottom: $base-margin !important;
+    }
+  }
 }
 
 .ml0{
@@ -124,19 +130,19 @@
 }
 
 .pt1 {
-  padding-top: $base-margin !important;
+  padding-top: $base-padding !important;
 }
 
 .pr1 {
-  padding-right: $base-margin !important;
+  padding-right: $base-padding !important;
 }
 
 .pb1 {
-  padding-bottom: $base-margin !important;
+  padding-bottom: $base-padding !important;
 }
 
 .pl1 {
-  padding-left: $base-margin !important;
+  padding-left: $base-padding !important;
 }
 
 .p0{
@@ -153,6 +159,12 @@
 
 .pb0 {
   padding-bottom :0 !important;
+
+  &--mobile-pb1{
+    @include breakpoint(small only){
+      padding-bottom: $base-padding !important;
+    }
+  }
 }
 
 .pl0 {

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.0.5'
+    VERSION = '1.0.6'
   end
 end


### PR DESCRIPTION
- This allows the margin/padding to be set to 0px only for desktop layouts, while leaving it as the base value for mobile.
- Used for navigation buttons in Insurance.
- Also using $base-padding instead of $base-margin for padding values,
  as they should be.

🎨 