### PR TITLE
Added class to properly align month/year date inputs

### DIFF
--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -215,6 +215,17 @@ input[type="checkbox"]{
   }
 }
 
+.date-pair{
+  .month,
+  .year {
+    @extend %inputs-halves;
+
+    &:last-of-type{
+      float: right;
+    }
+  }
+}
+
 .minute{
   float: right;
 }

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.0.10'
+    VERSION = '1.0.11'
   end
 end


### PR DESCRIPTION
- Existing styles assume a year/month/day set of inputs, so the layout breaks when day element is removed.
- New class is applied to the div wrapping the date inputs.

Desktop:
![image](https://cloud.githubusercontent.com/assets/473578/24921883/946cacf6-1ea9-11e7-80ed-988665ecf6e7.png)

Mobile:
![image](https://cloud.githubusercontent.com/assets/473578/24922268/ff9a40a0-1eaa-11e7-8ce5-cbd24b85aa48.png)

https://ama-digital.myjetbrains.com/youtrack/issue/INSGW-119
🎨 
