### PR TITLE
Forcing white links to be underlined

### DIFF
--- a/app/assets/stylesheets/layout_components/links.scss
+++ b/app/assets/stylesheets/layout_components/links.scss
@@ -1,6 +1,6 @@
 .link--white{
   color: $white;
-  text-decoration: underline;
+  text-decoration: underline !important;
 
   &:hover{
     color: $white;

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.0.12'
+    VERSION = '1.0.13'
   end
 end


### PR DESCRIPTION
- When class is used inside a modal, the underline gets overridden. Adding important so you get the styles you expect

![image](https://cloud.githubusercontent.com/assets/473578/25022300/8b41981c-2052-11e7-8002-4073f8410c9c.png)
:art: