### PR TITLE
RREPORT-1110 - Road Reports Scroll on Safari

### DIFF
--- a/app/assets/stylesheets/layout_components/footer.scss
+++ b/app/assets/stylesheets/layout_components/footer.scss
@@ -3,7 +3,7 @@ $footer-push-small: 594px;
 $footer-push-medium: 419px;
 $footer-push-large: 321px;
 
-.off-canvas-wrapper{
+.off-canvas-wrapper:not(.no-footer){
   min-height: 100%;
 
   @include breakpoint(small only){
@@ -29,7 +29,7 @@ $footer-push-large: 321px;
     @include breakpoint(medium only){
       height: $footer-push-medium;
     }
-    
+
     @include breakpoint(large up){
       height: $footer-push-large;
     }

--- a/app/assets/stylesheets/layout_components/siteheader.scss
+++ b/app/assets/stylesheets/layout_components/siteheader.scss
@@ -72,6 +72,7 @@
     }
   }
 }
+
 .off-canvas-wrapper{
   /* for some reason foundation sets this to hidden for off-canvas by default,
   which causes issues with the cart's window.scrollTop in webkit


### PR DESCRIPTION
:art:

* Road reports uses ama_styles, but does not have a page footer.
* The off-canvas-wrapper class has an :after attribute on it to
  set the height of a page footer for our sticky footer.
* Because roadreports has no footer, add a :not css pseudoclass
  to conditionally add the footer extra space only when
  neccessary.

SEE: https://ama-digital.myjetbrains.com/youtrack/issue/RREPORT-1110