### PR TITLE
RREPORT-1110 - Road Reports Scrolling in Safari

### DIFF
--- a/app/assets/stylesheets/layout_components/buttons/button-toggle.scss
+++ b/app/assets/stylesheets/layout_components/buttons/button-toggle.scss
@@ -6,7 +6,7 @@
   &--absolute{
     @extend .button-toggle;
     position: absolute;
-    top: 15px;
+    top: 15px + $top-bar-height;
     width: 95%;
     left: 2.5%;
   }

--- a/app/assets/stylesheets/layout_components/siteheader.scss
+++ b/app/assets/stylesheets/layout_components/siteheader.scss
@@ -81,7 +81,9 @@
 }
 
 .top-nav-offset{
-  margin-top: $top-bar-height;
+  @include breakpoint (medium up){
+    margin-top: $top-bar-height;
+  }
 }
 
 .title-bar{

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.0.13'
+    VERSION = '1.0.14'
   end
 end


### PR DESCRIPTION
:art:

* Road reports uses a `top-nav-offset` class to provide extra space
  for the actual page on desktop screen sizes.
* On smaller sizes, the navigation components are hidden so we must also
  hide the offset spacer to prevent page scrolling.

SEE: https://ama-digital.myjetbrains.com/youtrack/issue/RREPORT-1110