### PR TITLE
RREPORT-1110 - Mobile Scrolling

### DIFF
--- a/app/assets/stylesheets/layout_components/buttons/button-toggle.scss
+++ b/app/assets/stylesheets/layout_components/buttons/button-toggle.scss
@@ -6,7 +6,7 @@
   &--absolute{
     @extend .button-toggle;
     position: absolute;
-    top: 15px + $top-bar-height;
+    top: 15px;
     width: 95%;
     left: 2.5%;
   }

--- a/app/assets/stylesheets/layout_components/footer.scss
+++ b/app/assets/stylesheets/layout_components/footer.scss
@@ -3,6 +3,12 @@ $footer-push-small: 594px;
 $footer-push-medium: 419px;
 $footer-push-large: 321px;
 
+.off-canvas-wrapper{
+  &.no-footer{
+    height: 100%;
+  }
+}
+
 .off-canvas-wrapper:not(.no-footer){
   min-height: 100%;
 

--- a/app/assets/stylesheets/layout_components/legends/legend-map.scss
+++ b/app/assets/stylesheets/layout_components/legends/legend-map.scss
@@ -9,7 +9,7 @@
   z-index: 5;
 
   @include breakpoint(small down){
-    bottom: 30px;
+    bottom: 0;
     top: auto;
     width: 100%;
     position: fixed;

--- a/app/assets/stylesheets/layout_components/maps.scss
+++ b/app/assets/stylesheets/layout_components/maps.scss
@@ -15,7 +15,7 @@
     display: none;
 
     @include breakpoint(small down){
-      bottom: 155px;
+      bottom: 125px;
     }
   }
 }

--- a/app/assets/stylesheets/layout_components/siteheader.scss
+++ b/app/assets/stylesheets/layout_components/siteheader.scss
@@ -81,9 +81,7 @@
 }
 
 .top-nav-offset{
-  @include breakpoint (medium up){
-    margin-top: $top-bar-height;
-  }
+  margin-top: $top-bar-height;
 }
 
 .title-bar{

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.0.14'
+    VERSION = '1.0.15'
   end
 end


### PR DESCRIPTION
:art:

__Take Two__

* A first approach was used previously to remove the nav-offset
  in road reports on mobile. This worked for the most part, but
  due to existing css/markup, all overlay elements had to be pushed
  down.
* Revert the recent changes described above.
* Instead, we need to set the off-canvas-wrapper height to 100% for the
  `no-footer` variant so that the page does not scroll on mobile.

SEE: https://ama-digital.myjetbrains.com/youtrack/issue/RREPORT-1110