### PR TITLE
Upgrade foundation 6.3

### DIFF
--- a/ama_styles.gemspec
+++ b/ama_styles.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'rails', '>= 4.2'
-  s.add_dependency 'foundation-rails', '~> 6.2.4.0'
+  s.add_dependency 'foundation-rails', '~> 6.3.1.0'
   s.add_dependency 'sass-rails'
   s.add_dependency 'font-awesome-sass'
   s.add_dependency 'redis-rails'

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -402,7 +402,7 @@ $offcanvas-background: $white;
 $offcanvas-zindex: -1;
 $offcanvas-transition-length: 0.5s;
 $offcanvas-transition-timing: ease;
-$offcanvas-fixed-reveal: true;
+$offcanvas-fixed-reveal: false;
 $offcanvas-exit-background: none;
 $maincontent-class: 'off-canvas-content';
 $maincontent-shadow: none;

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -59,7 +59,7 @@ $light-gray: #e6e6e6;
 $medium-gray: #cacaca;
 $dark-gray: #8a8a8a;
 $black: #0a0a0a;
-$white: #ffffff;
+$white: $white;
 $body-background: $stone;
 $body-font-color: $slate;
 $body-font-family: 'Open Sans', Helvetica, Roboto, Arial, sans-serif;

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -521,6 +521,7 @@ $tab-content-background: $white;
 $tab-content-border: none;
 $tab-content-color: foreground($tab-background, $primary-color);
 $tab-content-padding: 0;
+$tab-color: #ffffff;
 
 // 33. Thumbnail
 // -------------

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -59,7 +59,7 @@ $light-gray: #e6e6e6;
 $medium-gray: #cacaca;
 $dark-gray: #8a8a8a;
 $black: #0a0a0a;
-$white: $white;
+$white: #ffffff;
 $body-background: $stone;
 $body-font-color: $slate;
 $body-font-family: 'Open Sans', Helvetica, Roboto, Arial, sans-serif;
@@ -521,7 +521,7 @@ $tab-content-background: $white;
 $tab-content-border: none;
 $tab-content-color: foreground($tab-background, $primary-color);
 $tab-content-padding: 0;
-$tab-color: #ffffff;
+$tab-color: $white;
 
 // 33. Thumbnail
 // -------------

--- a/app/assets/stylesheets/layout/mixins-grid.scss
+++ b/app/assets/stylesheets/layout/mixins-grid.scss
@@ -59,157 +59,157 @@
 }
 
 @mixin medium-12{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(12);
   }
 }
 
 @mixin medium-11{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(11);
  }
 }
 
 @mixin medium-10{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(10);
   }
 }
 
 @mixin medium-9{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(9);
   }
 }
 
 @mixin medium-8{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(8);
   }
 }
 
 @mixin medium-7{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(7);
   }
 }
 
 @mixin medium-6{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(6);
   }
 }
 
 @mixin medium-5{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(5);
   }
 }
 
 @mixin medium-4{
-  @media #{$medium-up}{
+  @include breakpoint(medium up) {
     @include grid-column(4);
   }
 }
 
 @mixin medium-3{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(3);
   }
 }
 
 @mixin medium-2{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(2);
   }
 }
 
 @mixin medium-1{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column(1);
   }
 }
 
 @mixin large-12{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(12);
   }
 }
 
 @mixin large-11{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(11);
   }
 }
 
 @mixin large-10{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(10);
   }
 }
 
 @mixin large-9{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(9);
   }
 }
 
 @mixin large-8{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(8);
   }
 }
 
 @mixin large-7{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(7);
   }
 }
 
 @mixin large-6{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(6);
   }
 }
 
 @mixin large-5{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(5);
   }
 }
 
 @mixin large-4{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(4);
   }
 }
 
 @mixin large-3{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(3);
   }
 }
 
 @mixin large-2{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(2);
   }
 }
 
 @mixin large-1{
   @include small-12;
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column(1);
   }
 }
@@ -217,199 +217,199 @@
  /* Offset */
 
 @mixin small-offset-11{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(11);
   }
 }
 
 @mixin small-offset-10{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(10);
   }
 }
 
 @mixin small-offset-9{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(9);
   }
 }
 
 @mixin small-offset-8{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(8);
   }
 }
 
 @mixin small-offset-7{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(7);
   }
 }
 
 @mixin small-offset-6{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(6);
   }
 }
 
 @mixin small-offset-5{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(5);
   }
 }
 
 @mixin small-offset-4{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(4);
   }
 }
 
 @mixin small-offset-3{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(3);
   }
 }
 
 @mixin small-offset-2{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(2);
   }
 }
 
 @mixin small-offset-1{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-offset(1);
   }
 }
 
 @mixin medium-offset-11{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(11);
   }
 }
 
 @mixin medium-offset-10{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(10);
   }
 }
 
 @mixin medium-offset-9{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(9);
   }
 }
 
 @mixin medium-offset-8{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(8);
   }
 }
 
 @mixin medium-offset-7{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(7);
   }
 }
 
 @mixin medium-offset-6{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(6);
   }
 }
 
 @mixin medium-offset-5{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(5);
   }
 }
 
 @mixin medium-offset-4{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(4);
   }
 }
 
 @mixin medium-offset-3{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(3);
   }
 }
 
 @mixin medium-offset-2{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(2);
   }
 }
 
 @mixin medium-offset-1{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-offset(1);
   }
 }
 
 @mixin large-offset-11{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(11);
   }
 }
 
 @mixin large-offset-10{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(10);
   }
 }
 
 @mixin large-offset-9{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(9);
   }
 }
 
 @mixin large-offset-8{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(8);
   }
 }
 
 @mixin large-offset-7{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(7);
   }
 }
 
 @mixin large-offset-6{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(6);
   }
 }
 
 @mixin large-offset-5{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(5);
   }
 }
 
 @mixin large-offset-4{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(4);
   }
 }
 
 @mixin large-offset-3{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(3);
   }
 }
 
 @mixin large-offset-2{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(2);
   }
 }
 
 @mixin large-offset-1{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-offset(1);
   }
 }
@@ -417,202 +417,202 @@
 /* Push */
 
 @mixin small-push-11{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(11);
   }
 }
 
 @mixin small-push-10{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(10);
   }
 }
 
 @mixin small-push-9{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(9);
   }
 }
 
 @mixin small-push-8{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(8);
   }
 }
 
 @mixin small-push-7{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(7);
   }
 }
 
 @mixin small-push-6{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(6);
   }
 }
 
 @mixin small-push-5{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(5);
   }
 }
 
 @mixin small-push-4{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(4);
   }
 }
 
 @mixin small-push-3{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(3);
   }
 }
 
 
 @mixin small-push-2{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(2);
   }
 }
 
 @mixin small-push-1{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(1);
   }
 }
 
 @mixin medium-push-11{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(11);
   }
 }
 
 @mixin medium-push-10{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(10);
   }
 }
 
 @mixin medium-push-9{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(9);
   }
 }
 
 @mixin medium-push-8{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(8);
   }
 }
 
 @mixin medium-push-7{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(7);
   }
 }
 
 @mixin medium-push-6{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(6);
   }
 }
 
 @mixin medium-push-5{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(5);
   }
 }
 
 @mixin medium-push-4{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(4);
   }
 }
 
 @mixin medium-push-3{
-  @media #{$medium-up}{
+@include breakpoint(medium up){
     @include grid-column-position(3);
   }
 }
 
 
 @mixin medium-push-2{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(2);
   }
 }
 
 @mixin medium-push-1{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(1);
   }
 }
 
 @mixin large-push-11{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(11);
   }
 }
 
 @mixin large-push-10{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(10);
   }
 }
 
 @mixin large-push-9{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(9);
   }
 }
 
 @mixin large-push-8{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(8);
   }
 }
 
 @mixin large-push-7{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(7);
   }
 }
 
 @mixin large-push-6{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(6);
   }
 }
 
 @mixin large-push-5{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(5);
   }
 }
 
 @mixin large-push-4{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(4);
   }
 }
 
 @mixin large-push-3{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(3);
   }
 }
 
 
 @mixin large-push-2{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(2);
   }
 }
 
 @mixin large-push-1{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(1);
   }
 }
@@ -620,202 +620,202 @@
 /* Pull */
 
 @mixin small-pull-11{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(-11);
   }
 }
 
 @mixin small-pull-10{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(-10);
   }
 }
 
 @mixin small-pull-9{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(-9);
   }
 }
 
 @mixin small-pull-8{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(-8);
   }
 }
 
 @mixin small-pull-7{
-  @media #{$small-up}{
+@include breakpoint(small up){
     @include grid-column-position(-7);
   }
 }
 
 @mixin small-pull-6{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(-6);
   }
 }
 
 @mixin small-pull-5{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(-5);
   }
 }
 
 @mixin small-pull-4{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(-4);
   }
 }
 
 @mixin small-pull-3{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(-3);
   }
 }
 
 
 @mixin small-pull-2{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(-2);
   }
 }
 
 @mixin small-pull-1{
-  @media #{$small-up}{
+  @include breakpoint(small up){
     @include grid-column-position(-1);
   }
 }
 
 @mixin medium-pull-11{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-11);
   }
 }
 
 @mixin medium-pull-10{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-10);
   }
 }
 
 @mixin medium-pull-9{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-9);
   }
 }
 
 @mixin medium-pull-8{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-8);
   }
 }
 
 @mixin medium-pull-7{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-7);
   }
 }
 
 @mixin medium-pull-6{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-6);
   }
 }
 
 @mixin medium-pull-5{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-5);
   }
 }
 
 @mixin medium-pull-4{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-4);
   }
 }
 
 @mixin medium-pull-3{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-3);
   }
 }
 
 
 @mixin medium-pull-2{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-2);
   }
 }
 
 @mixin medium-pull-1{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(-1);
   }
 }
 
 @mixin large-pull-11{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-11);
   }
 }
 
 @mixin large-pull-10{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-10);
   }
 }
 
 @mixin large-pull-9{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-9);
   }
 }
 
 @mixin large-pull-8{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-8);
   }
 }
 
 @mixin large-pull-7{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-7);
   }
 }
 
 @mixin large-pull-6{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-6);
   }
 }
 
 @mixin large-pull-5{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-5);
   }
 }
 
 @mixin large-pull-4{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-4);
   }
 }
 
 @mixin large-pull-3{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-3);
   }
 }
 
 
 @mixin large-pull-2{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-2);
   }
 }
 
 @mixin large-pull-1{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(-1);
   }
 }
@@ -835,13 +835,13 @@
 }
 
 @mixin medium-centered{
-  @media #{$medium-up}{
+  @include breakpoint(medium up){
     @include grid-column-position(center);
   }
 }
 
 @mixin large-centered{
-  @media #{$large-up}{
+  @include breakpoint(large up){
     @include grid-column-position(center);
   }
 }

--- a/app/assets/stylesheets/layout/variables.scss
+++ b/app/assets/stylesheets/layout/variables.scss
@@ -29,7 +29,7 @@ $secondary-color: $brand-blue-light;
 // Fonts
 $font-family-sans-serif: "Open Sans", Helvetica, Arial, sans-serif;
 $font-family-headings: "Open Sans Semi-Bold", Helvetica, Arial, sans-serif;
-$base-font-size: 1rem;
+$base-font-size: 14px;
 $small-font-size: $base-font-size*0.75;
 $medium-font-size: $base-font-size*1.3;
 $large-font-size: $base-font-size*1.85;

--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -287,6 +287,9 @@ input[type='text'],
 textarea,
 select{
   margin-bottom: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 select.has-placeholder:nth-child(1){

--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -192,6 +192,28 @@ input[type="checkbox"]{
   }
 }
 
+.radio-centered input[type="radio"] + label{
+   padding: 0 0 46px 0;
+
+   &:before{
+     top: 100%;
+     margin-top: -35px;
+     left: 50%;
+     margin-left: -12px;
+   }
+
+   &:after{
+     top: 100%;
+     margin-top: -27px;
+     left: 50%;
+     margin-left: -4px;
+   }
+ }
+
+ .radio-centered input[type="radio"]:checked + label{
+   padding: 0 0 46px 0;
+ }
+
 // Scoped to avoid collisions with foundations datepicker
 .date{
   .month,

--- a/app/assets/stylesheets/layout_components/siteheader.scss
+++ b/app/assets/stylesheets/layout_components/siteheader.scss
@@ -80,7 +80,7 @@
 }
 
 .top-nav-offset{
-  margin-top: 33px;
+  margin-top: 19px;
 }
 
 .title-bar{

--- a/app/assets/stylesheets/layout_components/siteheader.scss
+++ b/app/assets/stylesheets/layout_components/siteheader.scss
@@ -81,7 +81,11 @@
 }
 
 .top-nav-offset{
-  margin-top: 19px;
+  margin-top: $top-bar-height;
+
+  &--styleguide{
+    margin-top: 19px;
+  }
 }
 
 .title-bar{

--- a/app/assets/stylesheets/layout_components/siteheader.scss
+++ b/app/assets/stylesheets/layout_components/siteheader.scss
@@ -80,7 +80,7 @@
 }
 
 .top-nav-offset{
-  margin-top: $top-bar-height;
+  margin-top: 33px;
 }
 
 .title-bar{

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.0.13'
+    VERSION = '1.1.0'
   end
 end

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.0.12'
+    VERSION = '1.0.13'
   end
 end


### PR DESCRIPTION
:art:

upgraded ama_styles to newest version of foundation 6.3.1.0
Fixed mixin grid because foundation made some changes that deprecated the code we were using.
had to change $base-font-size to a pixel value because with the rem value it kept throwing an error.
Added some styling to hide the automatic styling the drop down forms by the browser so we could display our custom styling.
After updating the space below the header changed, so I had to adjust the value of top-nav-offset.