### PR TITLE
MEMBR-1490 - DM Promo Premier Form

### DIFF
--- a/app/assets/stylesheets/layout_components/comparison-radios.scss
+++ b/app/assets/stylesheets/layout_components/comparison-radios.scss
@@ -124,6 +124,7 @@
         float: left;
         width: 25%;
         margin-bottom: 0;
+        height: 100%;
       }
     }
   }
@@ -185,6 +186,7 @@
       float: left;
       border-right: 2px solid $stone;
       border-left: 2px solid $stone;
+      height: 100%;
     }
   }
 
@@ -293,7 +295,7 @@
 
   &__divider{
     margin-bottom: 0;
-    
+
     @include breakpoint(small only){
       display: none;
     }

--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -104,11 +104,6 @@ input[type="radio"] + label{
   &:before{
     border-radius: 100%;
   }
-
-  &:after{
-    content: ' ';
-    transition: all .5s ease-in-out;
-  }
 }
 
 input[type="radio"]:checked + label{

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.0.15'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
:art:

* The coverage selection page has high complexity due to the
  number of elements that need to be equalized in height.
* Take an alternate approach and remove the number of equalizer
  elements on the page. We have to clearfix the container element
  becuase all of its children are floated - yet we want accurate
  height.
* Remove the after pseudo element on the checkbox inputs/labels.
  It was adding an unwanted transition and extra space for content.

### Example Equalizer Issue

<img width="861" alt="equalizer" src="https://cloud.githubusercontent.com/assets/6474230/25586096/037b56b8-2e5b-11e7-9e20-cba03d955915.png">

* Issues like above will be fixed after a few markup changes.


SEE: https://ama-digital.myjetbrains.com/youtrack/issue/MEMBR-1490