### PR TITLE
Fix Gift Radio Padding

### DIFF
--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -192,6 +192,28 @@ input[type="checkbox"]{
   }
 }
 
+.radio-centered input[type="radio"] + label{
+  padding: 0 0 46px 0;
+
+  &:before{
+    top: 100%;
+    margin-top: -35px;
+    left: 50%;
+    margin-left: -12px;
+  }
+
+  &:after{
+    top: 100%;
+    margin-top: -27px;
+    left: 50%;
+    margin-left: -4px;
+  }
+}
+
+.radio-centered input[type="radio"]:checked + label{
+  padding: 0 0 46px 0;
+}
+
 // Scoped to avoid collisions with foundations datepicker
 .date{
   .month,

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end


### PR DESCRIPTION
:art:

* Gift radios now need more padding when unchecked. The relevant
  CSS used to be inside of the membership application. Moving
  the necessary styles to this repo.
* Bump version.