### PR TITLE
Fix Sticky Footer

### DIFF
--- a/app/assets/stylesheets/layout_components/footer.scss
+++ b/app/assets/stylesheets/layout_components/footer.scss
@@ -3,6 +3,10 @@ $footer-push-small: 594px;
 $footer-push-medium: 419px;
 $footer-push-large: 321px;
 
+html, body{
+  height: 100%;
+}
+
 .off-canvas-wrapper{
   &.no-footer{
     height: 100%;

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.1.0'
+    VERSION = '1.2.0'
   end
 end


### PR DESCRIPTION
:art:

* The upgrade to Foundation 6.3 broke our sticky footer. The reason
  is that the `html` and `body` no longer have 100% height.
* Bump version.

## Broken
<img width="1946" alt="screen shot 2017-05-05 at 9 40 02 am" src="https://cloud.githubusercontent.com/assets/6474230/25753047/639ec0a6-3177-11e7-807b-795f9c5e2f73.png">

## Fixed
<img width="1516" alt="screen shot 2017-05-05 at 9 43 34 am" src="https://cloud.githubusercontent.com/assets/6474230/25753056/6922f330-3177-11e7-98c5-c48e125f9c54.png">
