### PR TITLE
adding media queries to fix mobile forms in membership

### DIFF
--- a/app/assets/stylesheets/layout_components/comparison-radios.scss
+++ b/app/assets/stylesheets/layout_components/comparison-radios.scss
@@ -1,8 +1,10 @@
 .comparison-radios{
-  &__wrapper{
-    @include grid-row-nest;
-    @include clearfix;
-    margin-bottom: $base-margin;
+  @include breakpoint(medium) {
+    &__wrapper{
+      @include grid-row-nest;
+      @include clearfix;
+      margin-bottom: $base-margin;
+    }
   }
 
   &__radio-full{

--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -204,6 +204,7 @@ input[type="checkbox"]{
 
    &:after{
      top: 100%;
+     top: 100%;
      margin-top: -27px;
      left: 50%;
      margin-left: -4px;
@@ -400,13 +401,15 @@ input[type="url"]:-ms-input-placeholder{
   color: darken($stone, 10%);
 }
 
-.form-container{
-  @include grid-row-nest;
-  @include large-9;
-  @include grid-column-end;
-  overflow: auto;
-  max-width: 1080px;
-  display: block;
+@include breakpoint(medium) {
+  .form-container{
+    @include grid-row-nest;
+    @include large-9;
+    @include grid-column-end;
+    overflow: auto;
+    max-width: 1080px;
+    display: block;
+  }
 }
 
 .button__row{

--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -204,7 +204,6 @@ input[type="checkbox"]{
 
    &:after{
      top: 100%;
-     top: 100%;
      margin-top: -27px;
      left: 50%;
      margin-left: -4px;

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.2.1'
+    VERSION = '1.2.2'
   end
 end


### PR DESCRIPTION
:art:

our membership form fields were not 100% width on mobile. This PR is to fix that, as well as the width of the comparison radios.

https://ama-digital.myjetbrains.com/youtrack/issue/OAUTH-1193

before:
<img width="194" alt="screen shot 2017-05-25 at 10 51 01 am" src="https://cloud.githubusercontent.com/assets/5930849/26460858/48c21f0a-4138-11e7-9bf7-286a0c2a5d37.png">
<img width="194" alt="screen shot 2017-05-25 at 10 50 49 am" src="https://cloud.githubusercontent.com/assets/5930849/26460865/50b22264-4138-11e7-9663-588526c8563b.png">

Now with this fix:
![screen shot 2017-05-25 at 10 50 06 am](https://cloud.githubusercontent.com/assets/5930849/26460877/5b896404-4138-11e7-8ec5-f388b378f1ae.png)
![screen shot 2017-05-25 at 10 50 17 am](https://cloud.githubusercontent.com/assets/5930849/26460881/62652394-4138-11e7-877a-eb4bfa687ce0.png)
