### PR TITLE
Update Rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
-task default: %w(spec rubocop)
+task default: %w[spec rubocop]

--- a/ama_styles.gemspec
+++ b/ama_styles.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop', '0.48.0'
+  s.add_development_dependency 'rubocop', '0.49.1'
   s.add_development_dependency 'factory_girl'
   s.add_development_dependency 'colorize'
   s.add_development_dependency 'hipchat'

--- a/lib/ama/styles/cache.rb
+++ b/lib/ama/styles/cache.rb
@@ -3,7 +3,7 @@
 module AMA
   module Styles
     class Cache
-      DELEGATIONS = %i(fetch read write delete clear).freeze
+      DELEGATIONS = %i[fetch read write delete clear].freeze
 
       class << self
         delegate(*DELEGATIONS, to: :store)

--- a/lib/ama/styles/internal/cli.rb
+++ b/lib/ama/styles/internal/cli.rb
@@ -4,8 +4,8 @@ module AMA
   module Styles
     module Internal
       class CLI
-        ENVIRONMENTS = %w(development staging production).freeze
-        COMMANDS = %w(deploy).freeze
+        ENVIRONMENTS = %w[development staging production].freeze
+        COMMANDS = %w[deploy].freeze
         InvalidArgument = Class.new(StandardError)
 
         attr_accessor :argv, :dry_run, :branch

--- a/lib/ama/styles/internal/environment.rb
+++ b/lib/ama/styles/internal/environment.rb
@@ -59,7 +59,7 @@ module AMA
         def configure_assets
           config.eager_load = false
           config.assets.css_compressor = :sass
-          config.assets.precompile += %w(shared.css)
+          config.assets.precompile += %w[shared.css]
         end
 
         def configure_api

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.2.2'
+    VERSION = '1.2.3'
   end
 end

--- a/spec/lib/ama/styles/internal/cli_spec.rb
+++ b/spec/lib/ama/styles/internal/cli_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe AMA::Styles::Internal::CLI do
-  let(:argv) { %w(staging deploy) }
+  let(:argv) { %w[staging deploy] }
   let(:branch) { 'my_branch' }
   let(:invalid_argument) { described_class::InvalidArgument }
   subject do
@@ -10,7 +10,7 @@ describe AMA::Styles::Internal::CLI do
 
   describe '#parse_and_execute' do
     context 'invalid command' do
-      let(:argv) { %w(staging push) }
+      let(:argv) { %w[staging push] }
 
       it 'raise invalid argument' do
         expect { subject.parse_and_execute }.to raise_error invalid_argument
@@ -18,7 +18,7 @@ describe AMA::Styles::Internal::CLI do
     end
 
     context 'missing command' do
-      let(:argv) { %w(staging) }
+      let(:argv) { %w[staging] }
 
       it 'raise invalid argument' do
         expect { subject.parse_and_execute }.to raise_error invalid_argument
@@ -26,7 +26,7 @@ describe AMA::Styles::Internal::CLI do
     end
 
     context 'invalid environment' do
-      let(:argv) { %w(test deploy) }
+      let(:argv) { %w[test deploy] }
 
       it 'raise invalid argument' do
         expect { subject.parse_and_execute }.to raise_error invalid_argument


### PR DESCRIPTION
🐘 
* Update rubocop as per security alert from gemnasium.
`RuboCop uses /tmp to store cache files insecurely. Malicious local
users could exploit this to tamper with cache files belonging to other
users.`
* Update syntax violations
![screen shot 2017-05-29 at 10 03 07 am](https://cloud.githubusercontent.com/assets/1048714/26556331/2c5ad178-4457-11e7-8eb9-bb3d3959210d.png)
