### PR TITLE
VSTS-524 - Increase Compatibility For Older Browsers

### DIFF
--- a/ama_styles.gemspec
+++ b/ama_styles.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'font-awesome-sass'
   s.add_dependency 'redis-rails'
   s.add_dependency 'dotenv-rails'
+  s.add_dependency 'autoprefixer-rails'
 
   s.add_development_dependency 'aws-sdk'
   s.add_development_dependency 'sqlite3'

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.2.3'
+    VERSION = '1.3.0'
   end
 end

--- a/lib/ama_styles.rb
+++ b/lib/ama_styles.rb
@@ -4,6 +4,7 @@
 require 'font-awesome-sass'
 require 'foundation/rails'
 require 'dotenv/rails-now'
+require 'autoprefixer-rails'
 
 # Internal
 require 'ama/styles/base'


### PR DESCRIPTION
:elephant:

* Even though we only *officially* support the last 2 releases of
  iOS (currently 9 and 10), we sometimes get support requests for
  users on older devices.
* Because of Foundation's use of `transform` CSS attributes in
  off canvas, older browsers were causing the offcanvas nav
  to overlap with the majority of the page. This completely
  made all our websites unusable.
* Use `autoprefixer-rails` to automatically add the appropriate
  vendor prefixes for CSS attributes for compatibility with the
  majority of browsers.

## Before Autoprefixer on iOS 8

<img width="320" alt="screen shot 2017-06-08 at 10 54 58 am" src="https://user-images.githubusercontent.com/6474230/26940736-0f91d78c-4c39-11e7-8704-29162e23fb03.png">

## After Autoprefixer on iOS 8

<img width="322" alt="screen shot 2017-06-08 at 10 56 46 am" src="https://user-images.githubusercontent.com/6474230/26940764-2fe249d6-4c39-11e7-8157-c5eecb3b8a6c.png">



SEE: https://amaabca.visualstudio.com/membership_backlog/_workitems?id=524