### PR TITLE
Fix Foundation Deprecations

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -108,22 +108,22 @@ $header-font-family: $body-font-family;
 $header-font-weight: 700;
 $header-font-style: normal;
 $font-family-monospace: Consolas, 'Liberation Mono', Courier, monospace;
-$header-sizes: (
+$header-styles: (
   small: (
-    'h1': 20,
-    'h2': 20,
-    'h3': 19,
-    'h4': 18,
-    'h5': 17,
-    'h6': 16,
+    'h1': ('font-size': 20),
+    'h2': ('font-size': 20),
+    'h3': ('font-size': 19),
+    'h4': ('font-size': 18),
+    'h5': ('font-size': 17),
+    'h6': ('font-size': 16),
   ),
   medium: (
-    'h1': 20,
-    'h2': 20,
-    'h3': 18,
-    'h4': 16,
-    'h5': 14,
-    'h6': 12,
+    'h1': ('font-size': 20),
+    'h2': ('font-size': 20),
+    'h3': ('font-size': 18),
+    'h4': ('font-size': 16),
+    'h5': ('font-size': 14),
+    'h6': ('font-size': 12),
   ),
 );
 $header-color: inherit;

--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -389,7 +389,12 @@ small.error{
 }
 
 .error__page-error{
-  @extend small.error;
+  display: block;
+  clear: both;
+  padding: 0.375rem 0.5625rem 0.5625rem;
+  font-size: $base-font-size;
+  background: $brand-red;
+  color: $white;
   margin-bottom: $base-margin;
 }
 

--- a/lib/ama/styles/internal/hipchat.rb
+++ b/lib/ama/styles/internal/hipchat.rb
@@ -28,11 +28,11 @@ module AMA
         private
 
         def client
-          ::HipChat::Client.new(api_token)
+          ::HipChat::Client.new(api_token, api_version: 'v1')
         end
 
         def api_token
-          ENV.fetch('HIPCHAT_TOKEN_V2')
+          ENV.fetch('HIPCHAT_TOKEN')
         end
 
         def room

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.11.1'
+    VERSION = '1.11.2'
   end
 end


### PR DESCRIPTION
:art: :elephant:

## Details

* Foundation deprecated the `header-sizes` variable name with
  version `6.3`. The new name is `header-styles` and it uses a
  slightly different format.
* Fix a SASS deprecation warning about extending from the compound
  selector `small.error`. This will be removed in a future version
  of SASS.
* Use version 1 of the HipChat API. Version 2 does not work properly with the hipchat gem.

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [X] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [X] Any applicable version numbers have been updated.
- [X] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [X] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [X] I have written a detailed PR message explaining what is being changed and why
- [X] I’ve linked to any relevant VSTS tickets
- [X] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
- [ ] ~I've added new components to the style guide (or have a PR in to add them).~

SEE: https://github.com/zurb/foundation-sites/pull/9419
SEE: https://github.com/sass/sass/issues/1599
SEE: https://amaabca.visualstudio.com/membership_backlog/_workitems?id=1735