### PR TITLE
Adds styles to comparison radios so they stack on mobile

### DIFF
--- a/app/assets/stylesheets/layout_components/comparison-radios.scss
+++ b/app/assets/stylesheets/layout_components/comparison-radios.scss
@@ -36,6 +36,43 @@
     text-align: center;
   }
 
+  &__radio-btn--stacked{
+    .comparison-radios__input + label{
+      @include breakpoint(small only){
+        overflow: hidden;
+      }
+
+      @include breakpoint(small){
+        padding: 0 0 46px 0;
+      }
+
+      &::before{
+        @include breakpoint(small){
+          top: 100%;
+          margin-top: -35px;
+          left: 50%;
+          margin-left: -12px;
+        }
+      }
+    }
+
+    input[type="radio"]:checked + label{
+
+      &::after{
+        @include breakpoint(small){
+          top: 100%;
+          margin-top: -27px;
+          left: 50%;
+          margin-left: -4px;
+        }
+      }
+    }
+
+    .comparison-radios__divider{
+      display: block;
+    }
+  }
+
   &__radio-btn--centered{
     .comparison-radios__input + label{
       @include breakpoint(small only){


### PR DESCRIPTION
### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [ ] I've added new components to the style guide (or have a PR in to add them).
- [x] Any applicable version numbers have been updated.
- [ ] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why.
- [x] I’ve linked to any relevant VSTS tickets.
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design.

Part of VSTS: https://amaabca.visualstudio.com/driver_education_backlog/_workitems?id=1735&_a=edit

This PR creates new styles which will allow us to create comparison radios which do not rearrange on mobile by using the class `.comparison-radios__radio-btn--stacked` instead of `.comparison-radios__radio-btn--centered`

These new styles should not have any effect on existing comparison radios. 

Currently being used on https://github.com/amaabca/driver_ed_public/pull/21

🎨 

New Styles | Old Styles
<img width="801" alt="screen shot 2017-09-05 at 2 36 01 pm" src="https://user-images.githubusercontent.com/27693833/30082308-9dcbd54e-9247-11e7-968d-3afdab8ebd5d.png">
