### PR TITLE
De styles

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -100,6 +100,11 @@ $grid-column-gutter: (
 );
 $grid-column-align-edge: true;
 $block-grid-max: 8;
+$grid-margin-gutters: (
+  small: 30px,
+  medium: 30px,
+);
+$grid-padding-gutters: $grid-margin-gutters;
 
 // 4. Base Typography
 // ------------------

--- a/app/assets/stylesheets/layout_components/comparison-radios.scss
+++ b/app/assets/stylesheets/layout_components/comparison-radios.scss
@@ -36,6 +36,43 @@
     text-align: center;
   }
 
+  &__radio-btn--stacked{
+    .comparison-radios__input + label{
+      @include breakpoint(small only){
+        overflow: hidden;
+      }
+
+      @include breakpoint(small){
+        padding: 0 0 46px 0;
+      }
+
+      &::before{
+        @include breakpoint(small){
+          top: 100%;
+          margin-top: -35px;
+          left: 50%;
+          margin-left: -12px;
+        }
+      }
+    }
+
+    input[type="radio"]:checked + label{
+
+      &::after{
+        @include breakpoint(small){
+          top: 100%;
+          margin-top: -27px;
+          left: 50%;
+          margin-left: -4px;
+        }
+      }
+    }
+
+    .comparison-radios__divider{
+      display: block;
+    }
+  }
+
   &__radio-btn--centered{
     .comparison-radios__input + label{
       @include breakpoint(small only){

--- a/app/assets/stylesheets/layout_components/sections.scss
+++ b/app/assets/stylesheets/layout_components/sections.scss
@@ -6,6 +6,56 @@
 .section{
   margin-bottom: $base-margin;
 
+  &__heading{
+    @extend .heading;
+    background: $brand-blue-light;
+
+    &--no-bg{
+      padding-bottom: $base-padding;
+    }
+
+    &--no-padding{
+      background: $brand-blue-light;
+      color: $white;
+    }
+
+    &--grey-bg{
+      @extend .heading;
+      background: $slate;
+    }
+
+    &--dark-blue-bg{
+      @extend .heading;
+      background: $brand-blue-dark;
+    }
+
+    &--accordion{
+      @extend .heading;
+      overflow: auto;
+      display: block;
+    }
+
+    &--orange{
+      @extend .heading;
+      background: $orange;
+    }
+
+    &--yellow{
+      @extend .heading;
+      background: $canary;
+    }
+
+    &--blue{
+      @extend .heading;
+      background: $brand-blue-light;
+    }
+
+    &--green{
+      @extend .heading;
+      background: $brand-green;
+    }
+  }
+
   &__content{
     background: $white;
     padding-top: $base-padding;
@@ -48,6 +98,7 @@
   @include clearfix;
 }
 
+/* Old, and/or improperly named classes - DO NOT RE-USE */
 .section-heading{
   @extend .heading;
   background: $brand-blue-light;


### PR DESCRIPTION
This PR creates new styles which are better in-line with our best practices moving forward. 

`&__radio-btn--stacked` is used to create radio comparisons which do not rearrange in mobile view.

note: THe file `app/assets/stylesheets/layout_components/comparison-radios.scss` has already been through code review before merging into this branch. 

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [ ] I've added new components to the style guide (or have a PR in to add them).
- [x] Any applicable version numbers have been updated.
- [x] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [x] I’ve linked to any relevant VSTS tickets
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design

🎨 