### PR TITLE
Fix Notification Badge Position

### DIFF
--- a/app/assets/stylesheets/layout_components/notification.scss
+++ b/app/assets/stylesheets/layout_components/notification.scss
@@ -8,8 +8,8 @@
     line-height: 1.5;
     font-weight: bold;
     position: absolute;
-    top: 15px;
-    right: 25px;
+    top: 10%;
+    right: 15%;
 
     &--styleguide{
       @extend .notification__badge;

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.19.0'
+    VERSION = '1.19.1'
   end
 end


### PR DESCRIPTION
:art:

* On the desktop view, our notification badge wasn't positioned
  properly.
* Use percentage to position the badge into the correct location.

### Broken

<img width="1364" alt="screen shot 2017-10-04 at 4 34 20 pm" src="https://user-images.githubusercontent.com/6474230/31202916-eadfc214-a921-11e7-8e39-197f3a0f0952.png">

### Fixed

<img width="1364" alt="screen shot 2017-10-04 at 4 29 00 pm" src="https://user-images.githubusercontent.com/6474230/31202856-a0a37d58-a921-11e7-9799-835dd307e984.png">


### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [X] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- ~I've added new components to the style guide (or have a PR in to add them)~
- [X] Any applicable version numbers have been updated.
- [X] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [X] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [X]  have written a detailed PR message explaining what is being changed and why.
- ~I’ve linked to any relevant VSTS tickets~
- [X] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design