### PR TITLE
adds bottom padding to hint

### DIFF
--- a/app/assets/stylesheets/layout/helper-classes.scss
+++ b/app/assets/stylesheets/layout/helper-classes.scss
@@ -460,7 +460,7 @@
   color: darken($smoke, 15%);
   font-style: italic;
   display: block;
-  padding-bottom: 0.5rem;
+  padding-bottom: $base-padding/2;
 
   &--white {
     @extend .hint;

--- a/app/assets/stylesheets/layout/helper-classes.scss
+++ b/app/assets/stylesheets/layout/helper-classes.scss
@@ -460,6 +460,7 @@
   color: darken($smoke, 15%);
   font-style: italic;
   display: block;
+  padding-bottom: 0.5rem;
 
   &--white {
     @extend .hint;

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.20.4'
+    VERSION = '1.20.5'
   end
 end


### PR DESCRIPTION
This PR adds a bottom padding to the hint in our forms. 

🎨 

<img width="657" alt="screen shot 2017-12-19 at 11 03 43 am" src="https://user-images.githubusercontent.com/27693833/34171777-dd7da0c0-e4ac-11e7-8d50-a6da05227eca.png">



- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [x] I've added new components to the style guide (or have a PR in to add them).
- [x] Any applicable version numbers have been updated.
- [x] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [x] I’ve linked to any relevant VSTS tickets
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
