### PR TITLE
Add text-decoration-none to button hover state

### DIFF
--- a/app/assets/stylesheets/layout_components/buttons/buttons.scss
+++ b/app/assets/stylesheets/layout_components/buttons/buttons.scss
@@ -5,6 +5,7 @@
   &:active,
   &:focus {
     background: lighten($button-background, 10%);
+    text-decoration: none;
   }
 
   &--green {

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.21.1'
+    VERSION = '1.21.2'
   end
 end


### PR DESCRIPTION
This PR adds `text-decoration: none;` to the `.button` hover state. Currently, this functionality exists on our buttons which are created using `<input>` tags, but it does not exist on buttons created using `<a>` tags. The style currently exists on the button, but not the hover state. 

I'm rolling this fix into this [VSTS card here.](https://amaabca.visualstudio.com/driver_education_backlog/_workitems?id=2056&_a=edit)

🎨 

Hover before (grey button):
<img width="1113" alt="screen shot 2018-01-03 at 1 26 17 pm" src="https://user-images.githubusercontent.com/27693833/34538471-b8835baa-f089-11e7-936f-dec2b9a9c5fd.png">

Hover after:
<img width="1112" alt="screen shot 2018-01-03 at 1 28 14 pm" src="https://user-images.githubusercontent.com/27693833/34538537-fb99c2ee-f089-11e7-8361-e5fd862655d3.png">



- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [ ] ~I've added new components to the style guide (or have a PR in to add them).~
- [x] Any applicable version numbers have been updated.
- [x] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [x] I’ve linked to any relevant VSTS tickets
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design

  
  
  