### PR TITLE
Vsts 892 initial checkbox

### DIFF
--- a/app/assets/stylesheets/layout_components/buttons/button-grouping.scss
+++ b/app/assets/stylesheets/layout_components/buttons/button-grouping.scss
@@ -75,6 +75,11 @@
         background: lighten($button-background, 10%);
       }
     }
+
+    &--disabled {
+      @extend .button-grouping__button;
+      cursor: not-allowed;
+    }
   }
 
   &__content {

--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -178,6 +178,17 @@ input[type="checkbox"] + label,
     border: $base-border;
   }
 
+  &.checkbox--no-label {
+    border: none;
+    background: none;
+    padding: 0;
+
+    &::before {
+      top: -10px;
+      left: 0px;
+    }
+  }
+
   .membership-card-header {
     border-bottom: $base-border;
     background: darken($ash, 4%);
@@ -270,6 +281,11 @@ input[type="checkbox"]:checked + label {
     -moz-transform: (scaleX(-1) rotate(180deg + -45deg));
     -moz-transform-origin: left top;
     animation: checkbox 0.8s;
+  }
+
+  &.checkbox--no-label::after {
+    top: 3px;
+    left: 4px;
   }
 
   &::before {

--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -185,7 +185,7 @@ input[type="checkbox"] + label,
 
     &::before {
       top: -10px;
-      left: 0px;
+      left: 0;
     }
   }
 

--- a/app/assets/stylesheets/layout_components/sections.scss
+++ b/app/assets/stylesheets/layout_components/sections.scss
@@ -12,6 +12,7 @@
 
     &--no-bg {
       padding-bottom: $base-padding;
+      color: $charcoal;
     }
 
     &--no-padding {

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.21.3'
+    VERSION = '1.22.0'
   end
 end


### PR DESCRIPTION
🎨 

[VSTS](https://amaabca.visualstudio.com/driver_education_backlog/_workitems?id=892&_a=edit)

This PR does 3 things:

1. It changes `.section__heading--no-bg` so that the text colour is darker (Charcoal, #656565) to bump up the hierarchy of our section__headings when they are outside of a background. 
2. It creates a `.button-grouping__button--disabled` class which will add the `not-allowed` cursor to `.button-grouping__button`s which we want to disable.
3. It creates a new way to use our checkboxes inside of a table. It is hiding the input border and background, and repositions the checkboxes themselves.


**1 & 2 Before:**

<img width="744" alt="screen shot 2018-01-11 at 1 59 55 pm" src="https://user-images.githubusercontent.com/27693833/34847189-c377c380-f6d7-11e7-98e5-8acde4a67c1a.png">

**1 & 2 After:**

<img width="936" alt="screen shot 2018-01-11 at 1 57 55 pm" src="https://user-images.githubusercontent.com/27693833/34847099-7d8419c8-f6d7-11e7-8fc4-427d08fa89fb.png">

**3 Desktop**
<img width="1055" alt="screen shot 2018-01-10 at 2 50 41 pm" src="https://user-images.githubusercontent.com/27693833/34847790-c1fb3878-f6d9-11e7-9f36-6c2c37a089e2.png">


**3 Tablet**
<img width="651" alt="screen shot 2018-01-10 at 2 55 49 pm" src="https://user-images.githubusercontent.com/27693833/34847785-c00895c4-f6d9-11e7-9d37-3e0afd7a961d.png">


**3 Mobile**
<img width="397" alt="screen shot 2018-01-10 at 2 56 40 pm" src="https://user-images.githubusercontent.com/27693833/34847782-beaeda6c-f6d9-11e7-8b1a-051706cca525.png">



### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [ ] I've added new components to the style guide (or have a PR in to add them).
- [x] Any applicable version numbers have been updated.
- [x] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [ ] I’ve linked to any relevant VSTS tickets
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
