### PR TITLE
VSTS-675 - Dynamic Auto Quote

### DIFF
--- a/app/assets/stylesheets/layout_components/buttons/buttons.scss
+++ b/app/assets/stylesheets/layout_components/buttons/buttons.scss
@@ -8,6 +8,18 @@
     text-decoration: none;
   }
 
+  &--green-centered {
+    @extend .button;
+    $button-background: $brand-green;
+    background: $button-background;
+
+    &:hover,
+    &:active,
+    &:focus {
+      background: lighten($button-background, 10%);
+    }
+  }
+
   &--green {
     @extend .button;
     $button-background: $brand-green;

--- a/app/assets/stylesheets/layout_components/callouts/quote-callout.scss
+++ b/app/assets/stylesheets/layout_components/callouts/quote-callout.scss
@@ -1,7 +1,52 @@
 .quote-callout {
-  &__content {
-    @include absolute-center;
+  &__container {
+    display: flex;
+    background: $white;
+
+    @include breakpoint(medium up) {
+      flex-direction: row;
+    }
+
+    @include breakpoint(small only) {
+      flex-direction: column;
+      height: 600px; // HACK: IE 11 can't determine the flex container height for columns.
+    }
+  }
+
+  &__price {
+    background: $cerulean;
+    color: $white;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     text-align: center;
-    width: 90%;
+    flex-basis: 50%;
+  }
+
+  &__contact {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    flex-basis: 50%;
+  }
+
+  &__arrow {
+    display: flex;
+    position: relative;
+
+    &--right {
+      width: 0;
+      border-left: 50px solid $cerulean;
+      border-top: 150px solid transparent;
+      border-bottom: 150px solid transparent;
+    }
+
+    &--down {
+      height: 0;
+      border-top: 20px solid $cerulean;
+      border-left: 46vw solid transparent;
+      border-right: 46vw solid transparent;
+    }
   }
 }

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.23.0'
+    VERSION = '1.24.0'
   end
 end


### PR DESCRIPTION
:art:

* Revisit the way that we present the final quote page to the user.
  Instead of using Foundation's equalizer to create 2 equal height
  columns, use flexbox.
* Instead of rendering an SVG node for the arrow on the quote page,
  use plain CSS. This is much more simple and we can now use
  relative positioning to simplify the process.

SEE: https://amaabca.visualstudio.com/insurance_backlog/_workitems?id=675

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [X] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- ~I've added new components to the style guide (or have a PR in to add them).~
- [X] Any applicable version numbers have been updated.
- [X] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [X] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [X] I have written a detailed PR message explaining what is being changed and why
- [X] I’ve linked to any relevant VSTS tickets
- [X] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design

### Examples

<img width="2083" alt="screen shot 2018-01-31 at 11 36 58 am" src="https://user-images.githubusercontent.com/6474230/35641981-f3cb9b68-067e-11e8-9a2a-842ad677ef0e.png">

<img width="1744" alt="screen shot 2018-01-31 at 11 36 22 am" src="https://user-images.githubusercontent.com/6474230/35642004-09c80730-067f-11e8-8191-a8ea965888e2.png">

<img width="499" alt="screen shot 2018-01-31 at 11 38 49 am" src="https://user-images.githubusercontent.com/6474230/35641921-c371db26-067e-11e8-95d4-0c344a5bc7a9.png">


