### PR TITLE
Updates spinner so that it works on narrower screen sizes

### DIFF
--- a/app/assets/stylesheets/layout_components/spinner.scss
+++ b/app/assets/stylesheets/layout_components/spinner.scss
@@ -8,7 +8,7 @@
 
   &--bounce {
     margin: 0 auto;
-    width: 70px;
+    width: 100%;
     text-align: center;
   }
 }

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.37.0'
+    VERSION = '1.38.0'
   end
 end


### PR DESCRIPTION
🎨 

This is a small edit to the existing spinner so that it will work on containers smaller than 70px. Previously on smaller sizes, the third 'dot' in the spinner would fall to the next line. 

I tested the new spinner out on full width screens and it doesn't seem to be affecting anything negatively at all. 

VSTS: https://amaabca.visualstudio.com/DX_UX_Bugs/_workitems/edit/13992

- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [ ] ~I've added new components to the style guide (or have a PR in to add them).~
- [x] Any applicable version numbers have been updated.
- [ ] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [x] I’ve linked to any relevant VSTS tickets
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
