### PR TITLE
Fix version  autoprefixer-rails

### DIFF
--- a/ama_styles.gemspec
+++ b/ama_styles.gemspec
@@ -13,28 +13,24 @@ Gem::Specification.new do |s|
     'Michael van den Beuken',
     'Ruben Estevez',
     'Jordan Babe',
-    'Mathieu Gilbert',
     'Jesse Doyle',
     'Ryan Jones',
     'Darko Dosenovic',
     'Jonathan Weyermann',
     'Zoie Carnegie',
     'Kayt Campbell',
-    'Kathleen Robertson',
     'Sinead Errity'
   ]
   s.email = [
     'michael.beuken@gmail.com',
     'ruben.a.estevez@gmail.com',
     'jorbabe@gmail.com',
-    'mathieu.gilbert@ama.ab.ca',
     'jesse.doyle@ama.ab.ca',
     'ryan.michael.jones@gmail.com',
     'darko.dosenovic@ama.ab.ca',
     'jonathan.weyermann@ama.ab.ca',
     'zoie.carnegie@ama.ab.ca',
     'kayt.campbell@ama.ab.ca',
-    'kathleen.robertson@ama.ab.ca',
     'sinead.errity@ama.ab.ca'
   ]
   s.homepage = 'https:/github.com/amaabca/ama_styles'
@@ -51,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'font-awesome-sass'
   s.add_dependency 'redis-rails'
   s.add_dependency 'dotenv-rails'
-  s.add_dependency 'autoprefixer-rails'
+  s.add_dependency 'autoprefixer-rails', '8.6.4'
 
   s.add_development_dependency 'aws-sdk'
   s.add_development_dependency 'sqlite3'

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '1.37.1'
+    VERSION = '1.38.0'
   end
 end


### PR DESCRIPTION
🐘 


Freezing version of  autoprefixer-rails to 8.6.4 which is working with older version of Node.js - 9.0. 
Removing emails which are not in use any more.

- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- ~[ ] I've added new components to the style guide (or have a PR in to add them).~
- [x] Any applicable version numbers have been updated.
- ~[ ] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.~
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- ~[ ] I’ve linked to any relevant VSTS tickets~
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
