### PR TITLE
VSTS 18371 - Adds styles from our react apps.

### DIFF
--- a/app/assets/stylesheets/layout/helper-classes.scss
+++ b/app/assets/stylesheets/layout/helper-classes.scss
@@ -587,3 +587,7 @@
     color: $brand-green;
   }
 }
+
+.flex {
+  display: flex !important;
+}

--- a/app/assets/stylesheets/layout/helper-classes.scss
+++ b/app/assets/stylesheets/layout/helper-classes.scss
@@ -132,6 +132,10 @@
   overflow: auto !important;
 }
 
+.flex {
+  display: flex !important;
+}
+
 /* ==================== 4. Margins ==================== */
 .m1 {
   margin: $base-margin !important;
@@ -586,8 +590,4 @@
     @extend .bold-large-text;
     color: $brand-green;
   }
-}
-
-.flex {
-  display: flex !important;
 }

--- a/app/assets/stylesheets/layout_components/breadcrumbs.scss
+++ b/app/assets/stylesheets/layout_components/breadcrumbs.scss
@@ -6,3 +6,25 @@
     }
   }
 }
+
+// styles for react app breadcrumbs
+// (breadcrumbs__section only exists in our react apps)
+.breadcrumbs__section {
+  &::after {
+    margin: 0 0.75rem;
+    content: "/";
+    color: $smoke;
+  }
+
+  &:last-child {
+    a {
+      color: $stormcloud;
+      pointer-events: none;
+      text-decoration: none;
+    }
+
+    &::after {
+      content: "";
+    }
+  }
+}

--- a/app/assets/stylesheets/layout_components/buttons/buttons.scss
+++ b/app/assets/stylesheets/layout_components/buttons/buttons.scss
@@ -153,6 +153,19 @@
     bottom: 0.5rem;
     z-index: 2;
   }
+
+  &__link {
+    line-height: inherit;
+    color: $cerulean;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+      color: lighten($cerulean, 15%);
+      text-decoration: none;
+    }
+  }
 }
 
 button.disabled,

--- a/app/assets/stylesheets/layout_components/side_nav.scss
+++ b/app/assets/stylesheets/layout_components/side_nav.scss
@@ -47,6 +47,8 @@
     font-weight: 600;
     color: $jet;
     margin-bottom: $base-margin/2;
+    cursor: pointer;
+    line-height: inherit;
   }
 
   &__child-list {

--- a/app/assets/stylesheets/layout_components/siteheader.scss
+++ b/app/assets/stylesheets/layout_components/siteheader.scss
@@ -164,4 +164,19 @@
   a {
     line-height: 2;
   }
+
+  .button__link {
+    background: none;
+    padding: 0.7rem 1rem;
+    line-height: 2;
+    margin-bottom: 0;
+  }
+
+  .header__link {
+    color: $white;
+
+    &:hover {
+      color: $white;
+    }
+  }
 }

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '2.3.0'
+    VERSION = '2.4.0'
   end
 end


### PR DESCRIPTION
🎨 

There are a few differences in how we are building our react apps that require some slight changes to how we are styling certain elements in our react apps. 

The big one is we are changing how we are using `<a>` tags in react apps, which means that for breadcrumbs, buttons, and some existing `<a>` tags without a 'href' destination, the styles were breaking. 

pulls styles from: https://github.com/amaabca/react-kart/blob/master/src/App.scss

These shouldn't affect any existing styles in our rails apps.

[VSTS 18371](https://amaabca.visualstudio.com/roadside_backlog/_workitems/edit/18371)

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [x] ~I've added new components to the style guide (or have a PR in to add them).~
- [x] Any applicable version numbers have been updated.
- [ ] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [x] I’ve linked to any relevant VSTS tickets
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
