### PR TITLE
adds missing hover state to side nave link

### DIFF
--- a/app/assets/stylesheets/layout_components/side_nav.scss
+++ b/app/assets/stylesheets/layout_components/side_nav.scss
@@ -49,6 +49,10 @@
     margin-bottom: $base-margin/2;
     cursor: pointer;
     line-height: inherit;
+
+    &:hover {
+      color: lighten($cerulean, 15%);
+    }
   }
 
   &__child-list {

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '2.4.0'
+    VERSION = '2.4.1'
   end
 end


### PR DESCRIPTION
This PR adds a missing hover state to side nave link, see screenshots below:

Before:

<img width="601" alt="Screen Shot 2019-03-14 at 10 13 58 AM" src="https://user-images.githubusercontent.com/27693833/54373019-25f35280-4642-11e9-8dda-d4916dea4207.png">


After:

<img width="598" alt="Screen Shot 2019-03-14 at 10 13 37 AM" src="https://user-images.githubusercontent.com/27693833/54373013-24298f00-4642-11e9-8a8d-48969d903beb.png">



### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [ ] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [ ] I've added new components to the style guide (or have a PR in to add them).
- [ ] Any applicable version numbers have been updated.
- [ ] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [ ] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [ ] I have written a detailed PR message explaining what is being changed and why
- [ ] I’ve linked to any relevant VSTS tickets
- [ ] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
