### PR TITLE
VSTS-165 - fix radio button select alignment

### DIFF
--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -170,7 +170,7 @@ input[type="checkbox"] + label,
     display: block;
     position: absolute;
     left: 10px;
-    top: 8px;
+    top: calc(50% - 12px);
     width: 24px;
     min-width: 24px;
     height: 24px;
@@ -215,7 +215,7 @@ input[type="checkbox"] + label,
   width: 85%;
   margin-top: 9px;
   margin-bottom: 9px;
-  margin-left: 32px;
+  margin-left: 38px;
 }
 
 input[type="radio"] + label {
@@ -239,7 +239,7 @@ input[type="radio"]:checked + label {
     content: "";
     position: absolute;
     display: block;
-    top: 16px;
+    top: calc(50% - 4px);
     left: 18px;
     background-color: $brand-blue-light;
     width: 8px;

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '2.5.0'
+    VERSION = '2.5.1'
   end
 end


### PR DESCRIPTION
- make the `::before` button sit in the middle of the radio button container
- make the `::after` button sit in the middle of the ::before button
- move the text over a little as it was crowding the button

VSTS: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/165

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [x] I've added new components to the style guide (or have a PR in to add them).
- [x] Any applicable version numbers have been updated.
- [x] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [x] I’ve linked to any relevant VSTS tickets
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
