### PR TITLE
ADO-2646 - RSA Appointments

### DIFF
--- a/app/assets/stylesheets/layout_components/buttons/button-grouping.scss
+++ b/app/assets/stylesheets/layout_components/buttons/button-grouping.scss
@@ -44,7 +44,7 @@
       @extend .button-grouping__text-button;
       $button-background: $slate;
       background: $button-background;
-      
+
       &:hover,
       &:active,
       &:focus {
@@ -63,6 +63,11 @@
     position: relative;
     width: 100%;
     padding: 2.5em 1.75em;
+
+    &--full {
+      @extend .button-grouping__button;
+      height: 100%;
+    }
 
     &--green {
       @extend .button-grouping__button;

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '2.8.0'
+    VERSION = '2.9.0'
   end
 end


### PR DESCRIPTION
* Add a `full` modifier to the button grouping elements so that
  we can allow the box to expand to the full height of the container
  (i.e. when using Foundation's equalizer).

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/2646
