### PR TITLE
ADO-2501 Chat Widget AMA Branding Deploy to Production

### DIFF
--- a/app/assets/stylesheets/layout_components/chat-widget.scss
+++ b/app/assets/stylesheets/layout_components/chat-widget.scss
@@ -1,0 +1,218 @@
+.cx-webchat.cx-theme-ama {
+  .cx-menu {
+    li.cx-branding-icon {
+      display: none;
+    }
+  }
+
+  .cx-form {
+    th {
+      .cx-control-label {
+        font-weight: normal;
+      }
+    }
+  }
+
+  .cx-message-group {
+    .cx-message .cx-avatar-wrapper {
+      .cx-avatar.agent {
+        svg.cx-svg-icon-tone1 {
+          fill: $brand-blue-light;
+        }
+      }
+    }
+  }
+
+  .cx-transcript {
+    .cx-message {
+      .cx-name {
+        font-weight: bold !important;
+      }
+    }
+
+    .cx-message.cx-you {
+      .cx-bubble {
+        background-color: $sky;
+      }
+    }
+
+    .cx-message.cx-them {
+      .cx-bubble {
+        background-color: $sky;
+      }
+    }
+
+    .cx-message.cx-date {
+      border: 2px solid $brand-blue-light !important;
+    }
+  }
+}
+
+.cx-common-container {
+  .cx-titlebar {
+    padding: 9px 20px !important;
+  }
+}
+
+.cx-bubble-arrow {
+  svg {
+    fill: $sky;
+  }
+}
+
+.cx-message.cx-date {
+  color: $brand-blue-light;
+}
+
+.cx-message-chat {
+  color: $brand-blue-light;
+}
+
+.cx-widget {
+  font-family: $font-family-sans-serif !important;
+}
+
+.cx-webchat div.cx-input-container {
+  border-width: 2px 0 0 !important;
+}
+
+.cx-widget.cx-theme-ama {
+  * {
+    border-color: $brand-blue-light;
+  }
+  color: $slate;
+  background-color: $white;
+
+  .cx-overlay {
+    background-color: $brand-blue-light;
+  }
+
+  .cx-svg-icon-tone1 {
+    fill: $white;
+  }
+
+  .cx-titlebar {
+    background: $brand-blue-light;
+
+    .cx-title {
+      color: $white;
+    }
+  }
+
+  .cx-form-control {
+    border-radius: 0;
+  }
+
+  .cx-buttons-window-control .cx-svg-icon-tone1 {
+    fill: $white;
+  }
+
+  .cx-input-icon-overlay .cx-svg-icon-tone1 {
+    fill: $white;
+  }
+
+  label {
+    color: $slate !important;
+  }
+
+  a {
+    color: $slate;
+  }
+
+  a:hover {
+    color: $brand-blue-light;
+  }
+
+  .cx-dropdown {
+    color: $jet;
+  }
+
+  .cx-icon-alert-circle {
+    color: $brand-red;
+  }
+
+  .cx-footer {
+    color: transparent;
+    height: 0;
+    padding: 10px;
+
+    * {
+      fill: transparent;
+    }
+  }
+
+  .cx-form-control.cx-error {
+    border-color: $brand-red;
+  }
+
+  .cx-form-control::placeholder {
+    color: $smoke;
+  }
+
+  .cx-form-control:-moz-placeholder {
+    color: $smoke;
+  }
+
+  .cx-form-control::-moz-placeholder {
+    color: $smoke;
+  }
+
+  .cx-form-control:-ms-input-placeholder {
+    color: $smoke;
+  }
+
+  .cx-form-control::-webkit-input-placeholder {
+    color: $smoke;
+  }
+
+  input:focus,
+  textarea:focus,
+  .cx-btn:focus,
+  .cx-button-group button:focus,
+  .cx-form-control:focus {
+    border-color: $ocean;
+    border-width: 2px;
+    border-style: solid;
+  }
+
+  input[type="text"],
+  input[type="email"],
+  input[type="tel"],
+  textarea {
+    background-color: $white;
+    color: $stormcloud;
+    border-color: $smoke;
+    border-width: 2px;
+    border-style: solid;
+  }
+
+  .cx-border-error {
+    border-color: $brand-red;
+  }
+
+  .cx-btn {
+    border-radius: 3px;
+    font-weight: normal;
+  }
+
+  .cx-btn-default {
+    border-color: $slate;
+    color: $white;
+    background-color: $slate;
+  }
+
+  .cx-btn.cx-disabled {
+    background: $slate;
+  }
+
+  .cx-btn-primary {
+    color: $white;
+    border-color: $cerulean;
+    background: $cerulean;
+  }
+
+  .cx-smokescreen {
+    background-color: $jet;
+    opacity: 0.7;
+  }
+}

--- a/app/assets/stylesheets/layout_components/chat-widget.scss
+++ b/app/assets/stylesheets/layout_components/chat-widget.scss
@@ -48,17 +48,6 @@
   }
 }
 
-.cx-common-container {
-  .cx-titlebar {
-    padding: 9px 20px !important;
-
-    .cx-title{
-      font-size: 20px;
-      font-weight: $header-font-weight;
-    }
-  }
-}
-
 .cx-bubble-arrow {
   svg {
     fill: $sky;
@@ -98,6 +87,7 @@
 
   .cx-titlebar {
     background: $brand-blue-light;
+    padding: 9px 20px !important;
 
     .cx-title {
       color: $white;

--- a/app/assets/stylesheets/layout_components/chat-widget.scss
+++ b/app/assets/stylesheets/layout_components/chat-widget.scss
@@ -51,6 +51,11 @@
 .cx-common-container {
   .cx-titlebar {
     padding: 9px 20px !important;
+
+    .cx-title{
+      font-size: 20px;
+      font-weight: $header-font-weight;
+    }
   }
 }
 
@@ -96,6 +101,8 @@
 
     .cx-title {
       color: $white;
+      font-size: 20px;
+      font-weight: $header-font-weight;
     }
   }
 

--- a/app/assets/stylesheets/layout_components/index.scss
+++ b/app/assets/stylesheets/layout_components/index.scss
@@ -8,6 +8,7 @@
 @import "buttons/index";
 @import "card";
 @import "cart";
+@import "chat-widget";
 @import "comparison-radios";
 @import "content-toggle";
 @import "credit-card";

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '2.10.0'
+    VERSION = '2.11.0'
   end
 end


### PR DESCRIPTION
https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/2501

We need to style the purecloud chat widget to look more like "AMA"

All classes are created by purecloud and I basically just have to overwrite them, there were a few times that using !important was necessary because of this.

This PR is also connected to this one: https://github.com/amaabca/membership/pull/939

Staging: https://stage-membership.ama.ab.ca/