### PR TITLE
ADO-4887 - Add "Full" Checkbox Label

### DIFF
--- a/app/assets/stylesheets/layout_components/forms.scss
+++ b/app/assets/stylesheets/layout_components/forms.scss
@@ -226,6 +226,11 @@ input[type="checkbox"] + label,
   margin-top: 9px;
   margin-bottom: 9px;
   margin-left: 38px;
+
+  &--full {
+    @extend .checkbox-label;
+    width: auto;
+  }
 }
 
 .checkbox-terms {

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '2.12.0'
+    VERSION = '2.13.0'
   end
 end


### PR DESCRIPTION
* There are instances where we have a large amount of text in a
  checkbox label and we may want more than the default 85% of
  the label width available to display the content.

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/4887