### PR TITLE
ADO 12956: Versioned Assets - asset-url Image Fix

### DIFF
--- a/app/assets/stylesheets/v2/layout_components/buttons/button-grouping.scss
+++ b/app/assets/stylesheets/v2/layout_components/buttons/button-grouping.scss
@@ -163,17 +163,17 @@
 
 /* Non Font Awesome/Symbolicon Icons */
 #card-icon {
-  background-image: asset-url("v2/membership/card-icon.png");
+  background-image: asset-url("membership/card-icon.png");
 }
 
 #coverage-icon {
-  background-image: asset-url("v2/membership/coverage-icon.png");
+  background-image: asset-url("membership/coverage-icon.png");
 }
 
 #family-icon {
-  background-image: asset-url("v2/membership/family-icon.png");
+  background-image: asset-url("membership/family-icon.png");
 }
 
 #laptop-icon {
-  background-image: asset-url("v2/membership/laptop-icon.png");
+  background-image: asset-url("membership/laptop-icon.png");
 }

--- a/app/assets/stylesheets/v2/layout_components/features.scss
+++ b/app/assets/stylesheets/v2/layout_components/features.scss
@@ -42,62 +42,62 @@
 
 #feature__image {
   &--devices {
-    background-image: asset-url(v2/gatekeeper/devices);
+    background-image: asset-url(gatekeeper/devices);
   }
 
   &--membership {
-    background-image: asset-url(v2/gatekeeper/membership);
+    background-image: asset-url(gatekeeper/membership);
   }
 
   &--vrar {
-    background-image: asset-url(v2/gatekeeper/vrar);
+    background-image: asset-url(gatekeeper/vrar);
   }
 
   &--automotive {
-    background-image: asset-url(v2/gatekeeper/automotive);
+    background-image: asset-url(gatekeeper/automotive);
   }
 
   &--rewards {
-    background-image: asset-url(v2/gatekeeper/rewards);
+    background-image: asset-url(gatekeeper/rewards);
   }
 
   &--subscriptions {
-    background-image: asset-url(v2/gatekeeper/subscriptions);
+    background-image: asset-url(gatekeeper/subscriptions);
   }
 
   &--gift-cards {
-    background-image: asset-url(v2/gatekeeper/gift-card);
+    background-image: asset-url(gatekeeper/gift-card);
   }
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
   #feature__image {
     &--devices {
-      background-image: asset-url(v2/gatekeeper/devices2x);
+      background-image: asset-url(gatekeeper/devices2x);
     }
 
     &--feature--membership {
-      background-image: asset-url(v2/gatekeeper/membership2x);
+      background-image: asset-url(gatekeeper/membership2x);
     }
 
     &--vrar {
-      background-image: asset-url(v2/gatekeeper/vrar2x);
+      background-image: asset-url(gatekeeper/vrar2x);
     }
 
     &--automotive {
-      background-image: asset-url(v2/gatekeeper/automotive2x);
+      background-image: asset-url(gatekeeper/automotive2x);
     }
 
     &--rewards {
-      background-image: asset-url(v2/gatekeeper/rewards2x);
+      background-image: asset-url(gatekeeper/rewards2x);
     }
 
     &--subscriptions {
-      background-image: asset-url(v2/gatekeeper/subscriptions2x);
+      background-image: asset-url(gatekeeper/subscriptions2x);
     }
 
     &--gift-cards {
-      background-image: asset-url(v2/gatekeeper/gift-card2x);
+      background-image: asset-url(gatekeeper/gift-card2x);
     }
   }
 }

--- a/app/assets/stylesheets/v3/layout_components/buttons/button-grouping.scss
+++ b/app/assets/stylesheets/v3/layout_components/buttons/button-grouping.scss
@@ -163,17 +163,17 @@
 
 /* Non Font Awesome/Symbolicon Icons */
 #card-icon {
-  background-image: asset-url("v3/membership/card-icon.png");
+  background-image: asset-url("membership/card-icon.png");
 }
 
 #coverage-icon {
-  background-image: asset-url("v3/membership/coverage-icon.png");
+  background-image: asset-url("membership/coverage-icon.png");
 }
 
 #family-icon {
-  background-image: asset-url("v3/membership/family-icon.png");
+  background-image: asset-url("membership/family-icon.png");
 }
 
 #laptop-icon {
-  background-image: asset-url("v3/membership/laptop-icon.png");
+  background-image: asset-url("membership/laptop-icon.png");
 }

--- a/app/assets/stylesheets/v3/layout_components/features.scss
+++ b/app/assets/stylesheets/v3/layout_components/features.scss
@@ -42,62 +42,62 @@
 
 #feature__image {
   &--devices {
-    background-image: asset-url(v3/gatekeeper/devices);
+    background-image: asset-url(gatekeeper/devices);
   }
 
   &--membership {
-    background-image: asset-url(v3/gatekeeper/membership);
+    background-image: asset-url(gatekeeper/membership);
   }
 
   &--vrar {
-    background-image: asset-url(v3/gatekeeper/vrar);
+    background-image: asset-url(gatekeeper/vrar);
   }
 
   &--automotive {
-    background-image: asset-url(v3/gatekeeper/automotive);
+    background-image: asset-url(gatekeeper/automotive);
   }
 
   &--rewards {
-    background-image: asset-url(v3/gatekeeper/rewards);
+    background-image: asset-url(gatekeeper/rewards);
   }
 
   &--subscriptions {
-    background-image: asset-url(v3/gatekeeper/subscriptions);
+    background-image: asset-url(gatekeeper/subscriptions);
   }
 
   &--gift-cards {
-    background-image: asset-url(v3/gatekeeper/gift-card);
+    background-image: asset-url(gatekeeper/gift-card);
   }
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
   #feature__image {
     &--devices {
-      background-image: asset-url(v3/gatekeeper/devices2x);
+      background-image: asset-url(gatekeeper/devices2x);
     }
 
     &--feature--membership {
-      background-image: asset-url(v3/gatekeeper/membership2x);
+      background-image: asset-url(gatekeeper/membership2x);
     }
 
     &--vrar {
-      background-image: asset-url(v3/gatekeeper/vrar2x);
+      background-image: asset-url(gatekeeper/vrar2x);
     }
 
     &--automotive {
-      background-image: asset-url(v3/gatekeeper/automotive2x);
+      background-image: asset-url(gatekeeper/automotive2x);
     }
 
     &--rewards {
-      background-image: asset-url(v3/gatekeeper/rewards2x);
+      background-image: asset-url(gatekeeper/rewards2x);
     }
 
     &--subscriptions {
-      background-image: asset-url(v3/gatekeeper/subscriptions2x);
+      background-image: asset-url(gatekeeper/subscriptions2x);
     }
 
     &--gift-cards {
-      background-image: asset-url(v3/gatekeeper/gift-card2x);
+      background-image: asset-url(gatekeeper/gift-card2x);
     }
   }
 }


### PR DESCRIPTION
See: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/12956

* when I had originally fixed a problem with webfonts asset-url
  prefixes, I mistaken also prefixed the image asset-urls.
  Images aren't versioned as they are part of the stylesheets
  directory.
