### PR TITLE
ADO-13019-font-awesome-sass dep. min requirement

### DIFF
--- a/ama_styles.gemspec
+++ b/ama_styles.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'autoprefixer-rails'
   s.add_dependency 'dotenv-rails'
-  s.add_dependency 'font-awesome-sass'
+  s.add_dependency 'font-awesome-sass', '>= 5.0.6'
   s.add_dependency 'foundation-rails', '~> 6.4.3.0'
   s.add_dependency 'rails', '>= 4.2'
   s.add_dependency 'redis-rails'


### PR DESCRIPTION
🐘 

Problem: many of our AMA applications could have a locked version of
font-awesome-sass from before we implemented ama_styles

Solution: This PR adds a minimum required version of font-awesome-sass
gem so that if any of our applications update ama_styles to version
3.2.0 they will be required to remove any Gemfile locks associated with
font-awesome-sass

- Add font-awesome-sass dependency to require greater than or equal to
  version 5.0.6 which changed the icon helper method `icon` to require
and additional param of style and started to use font-awesome 5

See:
https://github.com/FortAwesome/font-awesome-sass/commit/56136a6d8699ef4469e8b0ac9168d608ea6f9cc0
for reference

ADO LINK: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/13019
