### PR TITLE
styling member info card, adding fix that was missed on link lists

### DIFF
--- a/app/assets/stylesheets/v3/layout_components/link-list.scss
+++ b/app/assets/stylesheets/v3/layout_components/link-list.scss
@@ -7,10 +7,6 @@
 
     &--bordered {
       @extend .link-list__item;
-
-      &:not(:first-child) {
-        padding-top: $base-padding/2;
-      }
     }
 
     &--grey-bordered {

--- a/app/assets/stylesheets/v3/layout_components/member-info-card.scss
+++ b/app/assets/stylesheets/v3/layout_components/member-info-card.scss
@@ -1,7 +1,8 @@
 .member-info-card {
   background: $white;
-  padding: $base-padding $base-padding 0 $base-padding;
+  padding: $base-padding $base-padding $base-padding*2 $base-padding;
   margin-bottom: $base-margin;
+  border-bottom: $base-border;
 
   &__image {
     float: left;
@@ -25,7 +26,7 @@
   }
 
   &__details-container {
-    border-right: 2px solid $stone;
+    border-right: $base-border;
 
     @include breakpoint(small only) {
       &:last-of-type {


### PR DESCRIPTION
https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/13536

Styles the member info card, and adds a small fix that was missed on link lists.

New Style:

![image](https://user-images.githubusercontent.com/1906696/87983596-d9215680-ca95-11ea-9e3d-230670465873.png)


Old Style:
![image](https://user-images.githubusercontent.com/1906696/87983464-a70ff480-ca95-11ea-91f8-c220fe7cf958.png)

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [ ] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [ ] I've added new components to the style guide (or have a PR in to add them).
- [ ] Any applicable version numbers have been updated.
- [ ] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [ ] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [ ] I have written a detailed PR message explaining what is being changed and why
- [ ] I’ve linked to any relevant VSTS tickets
- [ ] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
