### PR TITLE
ADO 12948: Better Versioning

### DIFF
--- a/lib/ama/styles/globals.rb
+++ b/lib/ama/styles/globals.rb
@@ -5,6 +5,7 @@ module AMA
     module Globals
       GEM_ROOT_PATH = Gem.loaded_specs['ama_styles'].full_gem_path.freeze
       ASSET_PATH = File.join(GEM_ROOT_PATH, 'app', 'assets').freeze
+      AMA_STYLES_VERSION_KEY = 'ama_styles_version'
       CURRENT_STYLESHEET_DIGEST_KEY = 'current_stylesheet_digest'
       CURRENT_MANIFEST_KEY = 'current_manifest'
       CURRENT_DEPLOYMENT_DATE_KEY = 'deployed_on'

--- a/lib/ama/styles/resolver.rb
+++ b/lib/ama/styles/resolver.rb
@@ -12,10 +12,17 @@ module AMA
       end
 
       def version
-        @version ||= ama_styles_default_version
+        @version || cached_ama_styles_version
       end
 
       private
+
+      def cached_ama_styles_version
+        cached_version = Cache.read(AMA_STYLES_VERSION_KEY)
+        return ama_styles_default_version if ama_styles_versions.exclude?(cached_version)
+
+        cached_version
+      end
 
       def custom_asset_url
         URI.join(

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '3.4.0'
+    VERSION = '3.5.0'
   end
 end


### PR DESCRIPTION
See: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/12948

* We'll now be able to leverage a cache entry to pull the current
  ama_styles version for all applications. The implications of
  this is that we can roll out a version change with a single
  PR and deployment.
