### PR TITLE
ADO-14090 Cart bug fix, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,21 +73,7 @@ This will trigger compilation of your assets instead of using AWS cloudfront.
 
 ## Font Awesome icons
 
-To include the fontawesome all js in an application please add the following require to the desired application `app/assets/javascripts/application.js`
-
-### All FA
-
-- Minified
-
-```js
-// = require ama_styles/font-awesome/all.min
-```
-
-- Full
-
-```js
-// = require ama_styles/font-awesome/all
-```
+Font Awesome icons will now be served up via the fa kit in the ama_layout [v11.3.0](https://rubygems.org/gems/ama_layout/versions/11.3.0) partial `ama_layout_partial('font_awesome_pro_kit')`
 
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/app/assets/stylesheets/v3/layout_components/cart.scss
+++ b/app/assets/stylesheets/v3/layout_components/cart.scss
@@ -52,13 +52,6 @@
     float: right;
     color: $dark-grey-text;
     margin-top: -5px;
-
-    &::before {
-      font-family: FontAwesome, "Font Awesome 5 Free";
-      content: "\f07d";
-      color: $dark-grey-text;
-      font-size: 1.5rem;
-    }
   }
 
   &__item-count {

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '3.13.0'
+    VERSION = '3.13.1'
   end
 end


### PR DESCRIPTION
🎨

- update readme to reflect the removal of fa javascripts
- remove before on the accordion-toggle-icon for v3 which was added
  because the html fa pro icon was not showing at the time, this issue
has been resolved with the fa pro kit available via the ama_layout gem

ADO LINK: https://dev.azure.com/AMA-Ent/AMA-Ent/_boards/board/t/Red%20Team/Stories/?workitem=14090

With the before removal, shows only one arrow
![image](https://user-images.githubusercontent.com/3697591/90698721-b1f9a880-e23e-11ea-88ba-989ee63481ff.png)

