### PR TITLE
ADO 14330: Allow Version Override

### DIFF
--- a/lib/ama/styles/resolver.rb
+++ b/lib/ama/styles/resolver.rb
@@ -7,8 +7,8 @@ module AMA
       attr_accessor :remote
       attr_writer :version
 
-      def asset_path
-        remote ? custom_asset_url : "#{version}/#{PRIMARY_STYLESHEET_NAME}"
+      def asset_path(asset_version = version)
+        remote ? custom_asset_url(asset_version) : "#{asset_version}/#{PRIMARY_STYLESHEET_NAME}"
       end
 
       def version
@@ -24,16 +24,16 @@ module AMA
         cached_version
       end
 
-      def custom_asset_url
+      def custom_asset_url(asset_version = version)
         URI.join(
           Rails.configuration.cloudfront_url,
           ASSET_PREFIX,
-          current_revision
+          current_revision(asset_version)
         ).to_s
       end
 
-      def current_revision
-        Cache.read("#{CURRENT_STYLESHEET_DIGEST_KEY}/#{version}") || "#{version}/#{FALLBACK_STYLESHEET_FILE}"
+      def current_revision(asset_version = version)
+        Cache.read("#{CURRENT_STYLESHEET_DIGEST_KEY}/#{asset_version}") || "#{asset_version}/#{FALLBACK_STYLESHEET_FILE}"
       end
     end
   end

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '3.14.1'
+    VERSION = '3.14.2'
   end
 end

--- a/spec/lib/ama/styles/resolver_spec.rb
+++ b/spec/lib/ama/styles/resolver_spec.rb
@@ -97,6 +97,25 @@ describe AMA::Styles::Resolver do
         context 'when version is v3' do
           let(:version) { 'v3' }
 
+          context 'when version v2 is passed' do
+            before(:each) do
+              AMA::Styles::Cache.write(
+                "#{AMA::Styles::Globals::CURRENT_STYLESHEET_DIGEST_KEY}/v2",
+                "v2/#{asset_name}"
+              )
+            end
+
+            it 'returns the v2 cloudfront asset url' do
+              cloudfront_url = URI.join(
+                Rails.configuration.cloudfront_url,
+                AMA::Styles::Globals::ASSET_PREFIX,
+                'v2/',
+                asset_name
+              ).to_s
+              expect(subject.asset_path('v2')).to eq(cloudfront_url)
+            end
+          end
+
           it 'returns the v3 cloudfront asset url' do
             cloudfront_url = URI.join(
               Rails.configuration.cloudfront_url,


### PR DESCRIPTION
See: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/14330

* allow version override so that apps that have some assets on v2
  and others on v3 will work
