### PR TITLE
ADO-10169 Remove Cancel Button Showing

### DIFF
--- a/app/assets/stylesheets/v2/layout_components/chat-widget.scss
+++ b/app/assets/stylesheets/v2/layout_components/chat-widget.scss
@@ -217,7 +217,15 @@
   }
 }
 
-// Removes the Minimize and Close buttons in the Learners Prep App
-.cx-widget.cx-theme-ama.cx-de-mobile .cx-buttons-window-control {
-  display: none;
+// DEPEA mobile app specific
+.cx-widget.cx-theme-ama.cx-de-mobile {
+  // Removes the Minimize and Close buttons in the Learners Prep App
+  .cx-buttons-window-control {
+    display: none;
+  }
+
+  // Removes the Cancel button in the Learners Prep App
+  .cx-btn-default {
+    display: none;
+  }
 }

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '3.18.0'
+    VERSION = '3.19.0'
   end
 end


### PR DESCRIPTION
🎨

- Added CSS to hide the Cancel button from showing because if a user presses the cancel button from inside the DEPEA webview the cancel button will not interact with the mobile app, so the user is just left looking at a message that says the agent will be right with them.

**Before:**
![image](https://user-images.githubusercontent.com/3697591/97484884-f67c8100-191e-11eb-8f9e-4ee89b785f81.png)

**After:**
![image](https://user-images.githubusercontent.com/3697591/97484819-e19fed80-191e-11eb-906a-e0264d0d7e38.png)


ADO LINK: https://dev.azure.com/AMA-Ent/AMA-Ent/_boards/board/t/Red%20Team/Stories/?workitem=10169
