### PR TITLE
72417 - Lock font-awesome-sass gem to use <= 5.15.1

### DIFF
--- a/ama_styles.gemspec
+++ b/ama_styles.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'autoprefixer-rails'
   s.add_dependency 'dotenv-rails'
-  s.add_dependency 'font-awesome-sass', '>= 5.0.6'
+  s.add_dependency 'font-awesome-sass', '>= 5.0.6', '<= 5.15.1'
   s.add_dependency 'foundation-rails', '~> 6.4.3.0'
   s.add_dependency 'rails', '~> 5.0'
   s.add_dependency 'redis', '<= 4.8.1'

--- a/lib/ama/styles/version.rb
+++ b/lib/ama/styles/version.rb
@@ -2,6 +2,6 @@
 
 module AMA
   module Styles
-    VERSION = '3.30.0'
+    VERSION = '3.30.1'
   end
 end


### PR DESCRIPTION
🐘

- using the font-awesome-sass gem above 5.15.1 in a application using the ama_styles gem will break the test suite
- locked gemspec file to font-awesome-sass <= 5.15.1
- updated version

ADO LINK:
https://dev.azure.com/AMA-Ent/AMA-Ent/_boards/board/t/Red%20Team/Stories/?workitem=72417

AB#72417
